### PR TITLE
Add 10% keyboard step for color temperature arrows

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -25,6 +25,28 @@ slider.ondblclick = function(){
 	sliderReset();
 };
 
+
+document.addEventListener("keydown", function (event) {
+	if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+		return;
+	}
+
+	if (event.target === code) {
+		return;
+	}
+
+	var min = parseInt(slider.min);
+	var max = parseInt(slider.max);
+	var rangeStep = Math.round((max - min) * 0.1);
+	var value = parseInt(slider.value);
+	var nextValue = event.key === "ArrowRight" ? value + rangeStep : value - rangeStep;
+	nextValue = Math.min(max, Math.max(min, nextValue));
+
+	event.preventDefault();
+	slider.value = nextValue;
+	updateColor(nextValue);
+});
+
 toggleAdvanced.onclick = function() {
 	advanced.classList.toggle("hidden");
 	return false;


### PR DESCRIPTION
### Motivation
- Provide keyboard control so pressing `ArrowRight`/`ArrowLeft` increments/decrements the color temperature by a meaningful step instead of the default 1 unit.  
- Keep arrow-key behavior disabled while editing the advanced `code` textarea so cursor movement remains normal.

### Description
- Add a global `keydown` handler that listens for `ArrowLeft` and `ArrowRight` and ignores other keys.  
- Compute the step as `Math.round((max - min) * 0.1)` (10% of the hardcoded slider range) and apply it to `slider.value`.  
- Clamp the new value with `Math.min`/`Math.max`, call `updateColor(nextValue)`, set `slider.value`, and `event.preventDefault()` to suppress default behavior.  
- Skip the custom handling when `event.target === code` so typing in the advanced textarea is unaffected.

### Testing
- Ran `node --check js/index.js` to validate the modified script and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbda30761c8329a7cd8975f9e693d5)