### PR TITLE
Add HDR-aware brightness controls with keyboard shortcuts

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -56,6 +56,12 @@ input
     margin: .4rem;
 }
 
+input[type='checkbox']
+{
+    width: auto;
+    margin: 0 .35em 0 0;
+}
+
 input[type='range']
 {
     width: 24em;

--- a/index.html
+++ b/index.html
@@ -15,7 +15,14 @@
 <div id="picker">
 	<h3>💡<br>Video Conference Beauty Dish<br>💡️</h3>
 	<h5>Maximize Window 🖥️</h5>
-	<h5>Brightness ➡️ 100%</h5>
+	<h5 id="brightnessStatus">Brightness ➡️ 100%</h5>
+	<p>
+		<label for="hdrToggle">
+			<input type="checkbox" id="hdrToggle" checked>
+			HDR Boost (if supported)
+		</label>
+	</p>
+	<p><small>Shortcuts: ⬆️ brighter, ⬇️ dimmer</small></p>
 	<br>
 	<p><label for="slider">Color temperature: <span id="output"></span>K</label></p>
 	<input type="range" id="slider" name="volume" min="3000" max="8000">

--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,8 @@
 var dish = document.getElementById("dish");
 var slider = document.getElementById("slider");
 var output = document.getElementById("output");
+var brightnessStatus = document.getElementById("brightnessStatus");
+var hdrToggle = document.getElementById("hdrToggle");
 
 var toggleAdvanced = document.getElementById("toggleAdvanced");
 
@@ -12,10 +14,17 @@ var thumbnail = document.getElementById("thumbnail");
 var submit = document.getElementById("submit");
 var webcamPreview = document.getElementById("webcamPreview");
 
+var brightnessLevel = 100;
+var MIN_BRIGHTNESS = 10;
+var SDR_MAX_BRIGHTNESS = 100;
+var HDR_MAX_BRIGHTNESS = 200;
+var BRIGHTNESS_STEP = 5;
+var hdrSupported = window.matchMedia && window.matchMedia("(dynamic-range: high)").matches;
 
 updateColor(slider.value);
 code_output.innerHTML = eval(code.value);
-updateThumbnail()
+updateThumbnail();
+applyBrightness();
 
 slider.oninput = function(){
 	updateColor(slider.value);
@@ -28,11 +37,15 @@ slider.ondblclick = function(){
 toggleAdvanced.onclick = function() {
 	advanced.classList.toggle("hidden");
 	return false;
-}
+};
+
+hdrToggle.onchange = function() {
+	applyBrightness();
+};
 
 code.oninput = function(){
 	code_output.innerHTML = eval(code.value);
-	updateThumbnail()
+	updateThumbnail();
 };
 
 code.onkeydown = function(e){
@@ -44,8 +57,8 @@ code.onkeydown = function(e){
 submit.onclick = function(){
 	dish.style.background = thumbnail.style.background;
 	slider.value = (parseInt(slider.min) + parseInt(slider.max))/2;
-	output.innerHTML = "N/A ";
-}
+	output.innerHTML = "N/A";
+};
 
 var videoContainer = document.getElementById("videoContainer");
 var video = document.getElementById("videoElement");
@@ -63,6 +76,18 @@ webcamPreview.onclick = function (){
 		});
 	}
 };
+
+window.addEventListener("keydown", function(event) {
+	if (event.key === "ArrowUp") {
+		event.preventDefault();
+		changeBrightness(BRIGHTNESS_STEP);
+	}
+
+	if (event.key === "ArrowDown") {
+		event.preventDefault();
+		changeBrightness(-BRIGHTNESS_STEP);
+	}
+});
 
 window.dragMoveListener = dragMoveListener;
 
@@ -141,4 +166,27 @@ function sliderReset() {
 
 function updateThumbnail() {
 	thumbnail.style.background = code_output.innerHTML;
+}
+
+function getBrightnessMax() {
+	if (hdrToggle.checked && hdrSupported) {
+		return HDR_MAX_BRIGHTNESS;
+	}
+
+	return SDR_MAX_BRIGHTNESS;
+}
+
+function applyBrightness() {
+	var maxBrightness = getBrightnessMax();
+	brightnessLevel = Math.min(Math.max(brightnessLevel, MIN_BRIGHTNESS), maxBrightness);
+
+	dish.style.filter = "brightness(" + (brightnessLevel / 100) + ")";
+
+	var hdrState = hdrToggle.checked ? (hdrSupported ? "HDR on" : "HDR requested (unsupported)") : "HDR off";
+	brightnessStatus.innerHTML = "Brightness ➡️ " + brightnessLevel + "% (" + hdrState + ")";
+}
+
+function changeBrightness(delta) {
+	brightnessLevel += delta;
+	applyBrightness();
 }


### PR DESCRIPTION
### Motivation
- Enable higher perceived brightness on HDR-capable screens by exposing an HDR-aware control and integrating it into the brighter/dimmer model.
- Provide a simple on/off checkbox for HDR that defaults to enabled so users can opt out where undesired.
- Allow quick adjustments via keyboard by binding the up/down arrow keys to increase/decrease brightness.
- Surface the current brightness percent and HDR state in the UI for clearer feedback.

### Description
- Added an `HDR Boost (if supported)` checkbox (default checked) and a dynamic brightness status element in `index.html` to replace the static brightness text.
- Implemented HDR-aware brightness logic in `js/index.js` with `brightnessLevel` tracking, constants for `SDR_MAX_BRIGHTNESS`/`HDR_MAX_BRIGHTNESS`, HDR detection via `window.matchMedia("(dynamic-range: high)")`, and functions `getBrightnessMax()`, `applyBrightness()`, and `changeBrightness()` that use `filter: brightness(...)` to apply changes.
- Bound global keyboard shortcuts: `ArrowUp` increases brightness and `ArrowDown` decreases brightness, both routing through the HDR-aware `changeBrightness()` path.
- Added checkbox-specific styling in `css/style.css` to prevent the global `input` rule from forcing full width on the checkbox.
- Files changed: `index.html`, `js/index.js`, and `css/style.css`.

### Testing
- Ran `git diff --check` to validate the diff, and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbda7c8cf88329ad5b678916e3cd6e)