### PR TITLE
Use chroma.js brighten()/darken() for dish brightness

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -207,10 +207,15 @@ function getBrightnessMax() {
 function applyBrightness() {
 	var maxBrightness = getBrightnessMax();
 	brightnessLevel = Math.min(Math.max(brightnessLevel, MIN_BRIGHTNESS), maxBrightness);
-	var scaledLightness = dishBaseColor.lch()[0] * (brightnessLevel / 100);
-	scaledLightness = Math.min(100, Math.max(0, scaledLightness));
-	var baseLch = dishBaseColor.lch();
-	var adjustedColor = chroma.lch(scaledLightness, baseLch[1], baseLch[2]);
+	var brightnessOffset = (brightnessLevel - 100) / 100;
+	var brightnessScaleFactor = 2;
+	var adjustedColor = dishBaseColor;
+
+	if (brightnessOffset > 0) {
+		adjustedColor = dishBaseColor.brighten(brightnessOffset * brightnessScaleFactor);
+	} else if (brightnessOffset < 0) {
+		adjustedColor = dishBaseColor.darken(Math.abs(brightnessOffset) * brightnessScaleFactor);
+	}
 
 	dish.style.backgroundColor = adjustedColor.css();
 	dish.style.filter = "none";


### PR DESCRIPTION
### Motivation
- Replace manual LCH lightness scaling in `applyBrightness()` because it did not reliably handle custom/advanced hues, and use chroma.js built-in transforms to preserve hue behavior.

### Description
- In `js/index.js` replaced the previous LCH-based lightness scaling with a relative `brightnessOffset` and calls to `dishBaseColor.brighten()` / `dishBaseColor.darken()` inside `applyBrightness()`, while keeping existing brightness clamping and HDR status text unchanged.

### Testing
- Ran `node --check js/index.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2c766aa08329ac31b2398ec7fa2f)