### PR TITLE
Fix iOS webcam preview: position above browser chrome, tap to disable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -319,7 +319,7 @@ textarea
 {
     position: fixed;
     z-index: 3;
-    bottom: 0;
+    bottom: env(safe-area-inset-bottom, 0px);
     left: 0;
 
     margin: .5em;
@@ -327,9 +327,9 @@ textarea
 
 #videoContainer
 {
-    position: absolute;
+    position: fixed;
     z-index: 3;
-    bottom: 0;
+    bottom: env(safe-area-inset-bottom, 0px);
     left: 0;
 
     box-sizing: border-box;

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" >
 <head>
-  <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Beauty Dish</title>
 		<link rel="stylesheet" href="css/style.css">
 </head>

--- a/js/index.js
+++ b/js/index.js
@@ -200,6 +200,17 @@ interact("#videoContainer")
 
 		target.setAttribute("data-x", x);
 		target.setAttribute("data-y", y);
+	})
+	.on("tap", function() {
+		if (video.srcObject) {
+			video.srcObject.getTracks().forEach(function(track) { track.stop(); });
+			video.srcObject = null;
+		}
+		videoContainer.classList.add("hidden");
+		videoContainer.style.webkitTransform = videoContainer.style.transform = "";
+		videoContainer.removeAttribute("data-x");
+		videoContainer.removeAttribute("data-y");
+		webcamPreview.classList.remove("hidden");
 	});
 
 function dragMoveListener(event) {


### PR DESCRIPTION
- Add viewport-fit=cover to meta viewport to enable CSS safe area variables
- Change #videoContainer from position:absolute to position:fixed so it
  sits in the visual viewport rather than the layout viewport
- Use env(safe-area-inset-bottom) for bottom positioning on both the
  webcam preview button and video container, clearing the home indicator
- Add interact.js tap handler on the video container to stop all media
  tracks, reset state, and restore the enable button

https://claude.ai/code/session_014jVUsKenc97zVMhdgfXMLg